### PR TITLE
Update composer to use minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "curl/curl": "1.1.3"
+        "curl/curl": "^1.1.3"
     },
     "autoload": {
-	    "psr-0": {
-	      "Curl": "src/"
-	    }
- 	},
+        "psr-0": {
+          "Curl": "src/"
+        }
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
Change composer to use minimum major version of curl/curl instead of a fixed version